### PR TITLE
Try to implement devversion internal lstat patch

### DIFF
--- a/devversion-lstat-patch.patch
+++ b/devversion-lstat-patch.patch
@@ -1,0 +1,296 @@
+diff --git a/js/private/node-patches/fs.cjs b/js/private/node-patches/fs.cjs
+index acf3f797..05edbf9d 100644
+--- a/js/private/node-patches/fs.cjs
++++ b/js/private/node-patches/fs.cjs
+@@ -46,6 +46,11 @@ const _fs = require('node:fs');
+ const url = require('node:url');
+ const HOP_NON_LINK = Symbol.for('HOP NON LINK');
+ const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND');
++// TENZIN IMPORT SECTION
++const { internalBinding } = require('internal/test/binding');
++const { getStatsFromBinding } = require('internal/fs/utils');
++const internalFs = internalBinding('fs');
++const _originalStatFs = internalFs.lstat;
+ function patcher(fs = _fs, roots) {
+     fs = fs || _fs;
+     // Make the original version of the library available for when access to the
+@@ -723,6 +728,115 @@ function patcher(fs = _fs, roots) {
+             }
+         }
+     }
++    // TENZIN PATCH SECTION FOR NODE INTERNAL LSTAT BINDING
++    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
++    const eeguardStats = (path, bigint, stats, cb) => {
++        const statsObj = getStatsFromBinding(stats);
++        if (!statsObj.isSymbolicLink()) {
++            // the file is not a symbolic link so there is nothing more to do
++            return cb(null, stats);
++        }
++        path = resolvePathLike(path);
++        if (!canEscape(path)) {
++            // the file can not escaped the sandbox so there is nothing more to do
++            return cb(null, stats);
++        }
++        return guardedReadLink(path, (str) => {
++            if (str != path) {
++                // there are one or more hops within the guards so there is nothing more to do
++                return cb(null, stats);
++            }
++            // there are no hops so lets report the stats of the real file;
++            // we can't use origRealPath here since that function calls lstat internally
++            // which can result in an infinite loop
++            return unguardedRealPath(path, (err, str) => {
++                if (err) {
++                    if ('code' in err && err.code === 'ENOENT') {
++                        // broken link so there is nothing more to do
++                        return cb(null, stats);
++                    }
++                    return cb(err);
++                }
++                // Forward request to original callback.
++                const req2 = new internalFs.FSReqCallback(bigint);
++                req2.oncomplete = (err, realStats) => cb(err, realStats);
++                return _originalStatFs.call(internalFs, str, bigint, req2);
++            });
++        });
++    };
++    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
++    const eeguardStatsSync = (path, bigint, throwIfNoEntry, stats) => {
++        // No stats available.
++        if (!stats) {
++            return stats;
++        }
++        const statsObj = getStatsFromBinding(stats);
++        if (!statsObj.isSymbolicLink()) {
++            // the file is not a symbolic link so there is nothing more to do
++            return stats;
++        }
++        path = resolvePathLike(path);
++        if (!canEscape(path)) {
++            // the file can not escaped the sandbox so there is nothing more to do
++            return stats;
++        }
++        const guardedReadLink = guardedReadLinkSync(path);
++        if (guardedReadLink != path) {
++            // there are one or more hops within the guards so there is nothing more to do
++            return stats;
++        }
++        try {
++            path = unguardedRealPathSync(path);
++            // there are no hops so lets report the stats of the real file;
++            // we can't use origRealPathSync here since that function calls lstat internally
++            // which can result in an infinite loop
++            return _originalStatFs.call(internalFs, path, bigint, undefined, throwIfNoEntry);
++        }
++        catch (err) {
++            if (err.code === 'ENOENT') {
++                // broken link so there is nothing more to do
++                return stats;
++            }
++            throw err;
++        }
++    };
++    if (internalFs.lstat) {
++        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
++            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
++            // Better than escaping IMO
++            const st = new Error().stack;
++            const needsGuarding = st.includes('finalizeResolution (node:internal/modules/esm/resolve') && !st.includes('eeguardStats');
++            if (!needsGuarding || global.__insidePatchedLstat) {
++                return _originalStatFs
++                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry);
++            }
++            if (typeof reqCallback === 'symbol') {
++                return _originalStatFs
++                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry)
++                    .then((stats) => {
++                    return new Promise((resolve, reject) => {
++                        eeguardStats(path, bigint, stats, (err, guardedStats) => {
++                            err ? reject(err) : resolve(guardedStats);
++                        });
++                    });
++                });
++            }
++            else if (reqCallback !== undefined) {
++                // Just re-use the promise path above.
++                internalFs
++                    .lstat(path, bigint, internalFs.kUsePromises, throwIfNoEntry)
++                    .then((stats) => reqCallback(null, stats))
++                    .catch((err) => reqCallback(err));
++            }
++            else {
++                const stats = _originalStatFs.call(internalFs, path, bigint, undefined, throwIfNoEntry);
++                if (!stats) {
++                    return stats;
++                }
++                return eeguardStatsSync(path, bigint, throwIfNoEntry, stats);
++            }
++        };
++    }
+ }
+ exports.patcher = patcher;
+ // =========================================================================
+diff --git a/js/private/node-patches/src/fs.cts b/js/private/node-patches/src/fs.cts
+index b07d4a1a..26ab6bea 100644
+--- a/js/private/node-patches/src/fs.cts
++++ b/js/private/node-patches/src/fs.cts
+@@ -36,6 +36,12 @@ const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND')
+ 
+ type HopResults = string | typeof HOP_NON_LINK | typeof HOP_NOT_FOUND
+ 
++// TENZIN IMPORT SECTION
++const { internalBinding } = require('internal/test/binding');
++const { getStatsFromBinding } = require('internal/fs/utils');
++const internalFs = internalBinding('fs');
++const _originalStatFs = internalFs.lstat;
++
+ export function patcher(fs: any = _fs, roots: string[]) {
+     fs = fs || _fs
+     // Make the original version of the library available for when access to the
+@@ -819,6 +825,136 @@ export function patcher(fs: any = _fs, roots: string[]) {
+             }
+         }
+     }
++
++    // TENZIN PATCH SECTION FOR NODE INTERNAL LSTAT BINDING
++    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
++    const eeguardStats = (path, bigint, stats, cb) => {
++        const statsObj = getStatsFromBinding(stats);
++        if (!statsObj.isSymbolicLink()) {
++            // the file is not a symbolic link so there is nothing more to do
++            return cb(null, stats)
++        }
++
++        path = resolvePathLike(path)
++        if (!canEscape(path)) {
++            // the file can not escaped the sandbox so there is nothing more to do
++            return cb(null, stats);
++        }
++
++        return guardedReadLink(path, (str) => {
++            if (str != path) {
++                // there are one or more hops within the guards so there is nothing more to do
++                return cb(null, stats);
++            }
++            // there are no hops so lets report the stats of the real file;
++            // we can't use origRealPath here since that function calls lstat internally
++            // which can result in an infinite loop
++            return unguardedRealPath(path, (err, str) => {
++                if (err) {
++                    if ('code' in err && err.code === 'ENOENT') {
++                        // broken link so there is nothing more to do
++                        return cb(null, stats);
++                    }
++                    return cb(err);
++                }
++
++                // Forward request to original callback.
++                const req2 = new internalFs.FSReqCallback(bigint);
++                req2.oncomplete = (err, realStats) => cb(err, realStats);
++                return _originalStatFs.call(internalFs, str, bigint, req2);
++            })
++        })
++    }
++
++    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
++    const eeguardStatsSync = (path, bigint, throwIfNoEntry, stats) => {
++        // No stats available.
++        if (!stats) {
++            return stats
++        }
++
++        const statsObj = getStatsFromBinding(stats);
++        if (!statsObj.isSymbolicLink()) {
++            // the file is not a symbolic link so there is nothing more to do
++            return stats
++        }
++
++        path = resolvePathLike(path)
++        if (!canEscape(path)) {
++            // the file can not escaped the sandbox so there is nothing more to do
++            return stats
++        }
++
++        const guardedReadLink = guardedReadLinkSync(path);
++        if (guardedReadLink != path) {
++            // there are one or more hops within the guards so there is nothing more to do
++            return stats
++        }
++        try {
++            path = unguardedRealPathSync(path);
++
++            // there are no hops so lets report the stats of the real file;
++            // we can't use origRealPathSync here since that function calls lstat internally
++            // which can result in an infinite loop
++            return _originalStatFs.call(
++                internalFs,
++                path,
++                bigint,
++                undefined,
++                throwIfNoEntry
++            );
++        } catch (err) {
++            if (err.code === 'ENOENT') {
++                // broken link so there is nothing more to do
++                return stats;
++            }
++            throw err;
++        }
++    }
++
++    if (internalFs.lstat) {
++        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
++            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
++            // Better than escaping IMO
++            const st = new Error().stack;
++            const needsGuarding =
++                st.includes('finalizeResolution (node:internal/modules/esm/resolve') && !st.includes('eeguardStats');
++            if (!needsGuarding || global.__insidePatchedLstat) {
++                return _originalStatFs
++                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry);
++            }
++
++            if (typeof reqCallback === 'symbol') {
++                return _originalStatFs
++                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry)
++                    .then((stats) => {
++                        return new Promise((resolve, reject) => {
++                            eeguardStats(path, bigint, stats, (err, guardedStats) => {
++                                err ? reject(err) : resolve(guardedStats)
++                            });
++                        });
++                    });
++            } else if (reqCallback !== undefined) {
++                // Just re-use the promise path above.
++                internalFs
++                    .lstat(path, bigint, internalFs.kUsePromises, throwIfNoEntry)
++                    .then((stats) => reqCallback(null, stats))
++                    .catch((err) => reqCallback(err));
++            } else {
++                const stats = _originalStatFs.call(
++                    internalFs,
++                    path,
++                    bigint,
++                    undefined,
++                    throwIfNoEntry
++                );
++                if (!stats) {
++                    return stats
++                }
++                return eeguardStatsSync(path, bigint, throwIfNoEntry, stats);
++            }
++        }
++    }
+ }
+ 
+ // =========================================================================
+diff --git a/js/private/node_wrapper.sh b/js/private/node_wrapper.sh
+index fae2c2a5..7c346a8c 100755
+--- a/js/private/node_wrapper.sh
++++ b/js/private/node_wrapper.sh
+@@ -2,4 +2,4 @@
+ 
+ set -o pipefail -o errexit -o nounset
+ 
+-exec "$JS_BINARY__NODE_BINARY" --require "$JS_BINARY__NODE_PATCHES" "$@"
++exec "$JS_BINARY__NODE_BINARY" --expose-internals --require "$JS_BINARY__NODE_PATCHES" "$@"

--- a/js/private/node-patches/fs.cjs
+++ b/js/private/node-patches/fs.cjs
@@ -46,6 +46,11 @@ const _fs = require('node:fs');
 const url = require('node:url');
 const HOP_NON_LINK = Symbol.for('HOP NON LINK');
 const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND');
+// TENZIN IMPORT SECTION
+const { internalBinding } = require('internal/test/binding');
+const { getStatsFromBinding } = require('internal/fs/utils');
+const internalFs = internalBinding('fs');
+const _originalStatFs = internalFs.lstat;
 function patcher(fs = _fs, roots) {
     fs = fs || _fs;
     // Make the original version of the library available for when access to the
@@ -722,6 +727,115 @@ function patcher(fs = _fs, roots) {
                 return loc;
             }
         }
+    }
+    // TENZIN PATCH SECTION FOR NODE INTERNAL LSTAT BINDING
+    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
+    const eeguardStats = (path, bigint, stats, cb) => {
+        const statsObj = getStatsFromBinding(stats);
+        if (!statsObj.isSymbolicLink()) {
+            // the file is not a symbolic link so there is nothing more to do
+            return cb(null, stats);
+        }
+        path = resolvePathLike(path);
+        if (!canEscape(path)) {
+            // the file can not escaped the sandbox so there is nothing more to do
+            return cb(null, stats);
+        }
+        return guardedReadLink(path, (str) => {
+            if (str != path) {
+                // there are one or more hops within the guards so there is nothing more to do
+                return cb(null, stats);
+            }
+            // there are no hops so lets report the stats of the real file;
+            // we can't use origRealPath here since that function calls lstat internally
+            // which can result in an infinite loop
+            return unguardedRealPath(path, (err, str) => {
+                if (err) {
+                    if ('code' in err && err.code === 'ENOENT') {
+                        // broken link so there is nothing more to do
+                        return cb(null, stats);
+                    }
+                    return cb(err);
+                }
+                // Forward request to original callback.
+                const req2 = new internalFs.FSReqCallback(bigint);
+                req2.oncomplete = (err, realStats) => cb(err, realStats);
+                return _originalStatFs.call(internalFs, str, bigint, req2);
+            });
+        });
+    };
+    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
+    const eeguardStatsSync = (path, bigint, throwIfNoEntry, stats) => {
+        // No stats available.
+        if (!stats) {
+            return stats;
+        }
+        const statsObj = getStatsFromBinding(stats);
+        if (!statsObj.isSymbolicLink()) {
+            // the file is not a symbolic link so there is nothing more to do
+            return stats;
+        }
+        path = resolvePathLike(path);
+        if (!canEscape(path)) {
+            // the file can not escaped the sandbox so there is nothing more to do
+            return stats;
+        }
+        const guardedReadLink = guardedReadLinkSync(path);
+        if (guardedReadLink != path) {
+            // there are one or more hops within the guards so there is nothing more to do
+            return stats;
+        }
+        try {
+            path = unguardedRealPathSync(path);
+            // there are no hops so lets report the stats of the real file;
+            // we can't use origRealPathSync here since that function calls lstat internally
+            // which can result in an infinite loop
+            return _originalStatFs.call(internalFs, path, bigint, undefined, throwIfNoEntry);
+        }
+        catch (err) {
+            if (err.code === 'ENOENT') {
+                // broken link so there is nothing more to do
+                return stats;
+            }
+            throw err;
+        }
+    };
+    if (internalFs.lstat) {
+        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
+            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
+            // Better than escaping IMO
+            const st = new Error().stack;
+            const needsGuarding = st.includes('finalizeResolution (node:internal/modules/esm/resolve') && !st.includes('eeguardStats');
+            if (!needsGuarding || global.__insidePatchedLstat) {
+                return _originalStatFs
+                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry);
+            }
+            if (typeof reqCallback === 'symbol') {
+                return _originalStatFs
+                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry)
+                    .then((stats) => {
+                    return new Promise((resolve, reject) => {
+                        eeguardStats(path, bigint, stats, (err, guardedStats) => {
+                            err ? reject(err) : resolve(guardedStats);
+                        });
+                    });
+                });
+            }
+            else if (reqCallback !== undefined) {
+                // Just re-use the promise path above.
+                internalFs
+                    .lstat(path, bigint, internalFs.kUsePromises, throwIfNoEntry)
+                    .then((stats) => reqCallback(null, stats))
+                    .catch((err) => reqCallback(err));
+            }
+            else {
+                const stats = _originalStatFs.call(internalFs, path, bigint, undefined, throwIfNoEntry);
+                if (!stats) {
+                    return stats;
+                }
+                return eeguardStatsSync(path, bigint, throwIfNoEntry, stats);
+            }
+        };
     }
 }
 exports.patcher = patcher;

--- a/js/private/node-patches/src/fs.cts
+++ b/js/private/node-patches/src/fs.cts
@@ -36,6 +36,12 @@ const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND')
 
 type HopResults = string | typeof HOP_NON_LINK | typeof HOP_NOT_FOUND
 
+// TENZIN IMPORT SECTION
+const { internalBinding } = require('internal/test/binding');
+const { getStatsFromBinding } = require('internal/fs/utils');
+const internalFs = internalBinding('fs');
+const _originalStatFs = internalFs.lstat;
+
 export function patcher(fs: any = _fs, roots: string[]) {
     fs = fs || _fs
     // Make the original version of the library available for when access to the
@@ -816,6 +822,136 @@ export function patcher(fs: any = _fs, roots: string[]) {
             ) {
                 // this hop takes us out of the guard
                 return loc
+            }
+        }
+    }
+
+    // TENZIN PATCH SECTION FOR NODE INTERNAL LSTAT BINDING
+    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
+    const eeguardStats = (path, bigint, stats, cb) => {
+        const statsObj = getStatsFromBinding(stats);
+        if (!statsObj.isSymbolicLink()) {
+            // the file is not a symbolic link so there is nothing more to do
+            return cb(null, stats)
+        }
+
+        path = resolvePathLike(path)
+        if (!canEscape(path)) {
+            // the file can not escaped the sandbox so there is nothing more to do
+            return cb(null, stats);
+        }
+
+        return guardedReadLink(path, (str) => {
+            if (str != path) {
+                // there are one or more hops within the guards so there is nothing more to do
+                return cb(null, stats);
+            }
+            // there are no hops so lets report the stats of the real file;
+            // we can't use origRealPath here since that function calls lstat internally
+            // which can result in an infinite loop
+            return unguardedRealPath(path, (err, str) => {
+                if (err) {
+                    if ('code' in err && err.code === 'ENOENT') {
+                        // broken link so there is nothing more to do
+                        return cb(null, stats);
+                    }
+                    return cb(err);
+                }
+
+                // Forward request to original callback.
+                const req2 = new internalFs.FSReqCallback(bigint);
+                req2.oncomplete = (err, realStats) => cb(err, realStats);
+                return _originalStatFs.call(internalFs, str, bigint, req2);
+            })
+        })
+    }
+
+    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
+    const eeguardStatsSync = (path, bigint, throwIfNoEntry, stats) => {
+        // No stats available.
+        if (!stats) {
+            return stats
+        }
+
+        const statsObj = getStatsFromBinding(stats);
+        if (!statsObj.isSymbolicLink()) {
+            // the file is not a symbolic link so there is nothing more to do
+            return stats
+        }
+
+        path = resolvePathLike(path)
+        if (!canEscape(path)) {
+            // the file can not escaped the sandbox so there is nothing more to do
+            return stats
+        }
+
+        const guardedReadLink = guardedReadLinkSync(path);
+        if (guardedReadLink != path) {
+            // there are one or more hops within the guards so there is nothing more to do
+            return stats
+        }
+        try {
+            path = unguardedRealPathSync(path);
+
+            // there are no hops so lets report the stats of the real file;
+            // we can't use origRealPathSync here since that function calls lstat internally
+            // which can result in an infinite loop
+            return _originalStatFs.call(
+                internalFs,
+                path,
+                bigint,
+                undefined,
+                throwIfNoEntry
+            );
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                // broken link so there is nothing more to do
+                return stats;
+            }
+            throw err;
+        }
+    }
+
+    if (internalFs.lstat) {
+        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
+            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
+            // Better than escaping IMO
+            const st = new Error().stack;
+            const needsGuarding =
+                st.includes('finalizeResolution (node:internal/modules/esm/resolve') && !st.includes('eeguardStats');
+            if (!needsGuarding || global.__insidePatchedLstat) {
+                return _originalStatFs
+                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry);
+            }
+
+            if (typeof reqCallback === 'symbol') {
+                return _originalStatFs
+                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry)
+                    .then((stats) => {
+                        return new Promise((resolve, reject) => {
+                            eeguardStats(path, bigint, stats, (err, guardedStats) => {
+                                err ? reject(err) : resolve(guardedStats)
+                            });
+                        });
+                    });
+            } else if (reqCallback !== undefined) {
+                // Just re-use the promise path above.
+                internalFs
+                    .lstat(path, bigint, internalFs.kUsePromises, throwIfNoEntry)
+                    .then((stats) => reqCallback(null, stats))
+                    .catch((err) => reqCallback(err));
+            } else {
+                const stats = _originalStatFs.call(
+                    internalFs,
+                    path,
+                    bigint,
+                    undefined,
+                    throwIfNoEntry
+                );
+                if (!stats) {
+                    return stats
+                }
+                return eeguardStatsSync(path, bigint, throwIfNoEntry, stats);
             }
         }
     }

--- a/js/private/node_wrapper.sh
+++ b/js/private/node_wrapper.sh
@@ -2,4 +2,4 @@
 
 set -o pipefail -o errexit -o nounset
 
-exec "$JS_BINARY__NODE_BINARY" --require "$JS_BINARY__NODE_PATCHES" "$@"
+exec "$JS_BINARY__NODE_BINARY" --expose-internals --require "$JS_BINARY__NODE_PATCHES" "$@"


### PR DESCRIPTION
From @devversion's original comment HERE: https://github.com/aspect-build/rules_js/issues/362#issuecomment-2950303149

Had to make some slight edits to get it to pass `tsc` compilation (seems like there was a bug where there's an unused variable `p` in `eeguardStatsSync`, and also `tsc` complains about the typing on some of the errors). After editing `js/private/node-patches/src/fs.cts`, I just generated the `cjs` file using `bazel run //js/private/node-patches:checked_in_compile`.

Within our own bazel repo this fixed the issue where ESM imports were escaping the runfiles and allowed our playwright tests to run successfully (without the runfiles escape implemented, Node was importing `playwright/globals` from both the symlink path and the realpath, leading to two copies of the global variables, messing with playwright's test file detection).

Unfortunate downside is that running the code using these internal bindings leads to these annoying process warnings firing: https://github.com/nodejs/node/blob/7f2d61f82abfb4203879e508fac976fff04dadde/lib/internal/test/binding.js#L9-L11

Some sample output that the internal binding warning emits when we were running bazel tests:
```
(node:1993956) internal/test/binding: These APIs are for internal testing only. Do not use them.
(Use `node --trace-warnings ...` to show where the warning was created)
```

I guess it's still a fair tradeoff if we can avoid a sandbox escape though.