### PR TITLE
Tenzin/devversion lstat patch optional

### DIFF
--- a/devversion-lstat-patch.patch
+++ b/devversion-lstat-patch.patch
@@ -1,19 +1,63 @@
+diff --git a/devversion-lstat-patch.patch b/devversion-lstat-patch.patch
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/js/private/js_binary.bzl b/js/private/js_binary.bzl
+index a059ad10..5d770bf8 100644
+--- a/js/private/js_binary.bzl
++++ b/js/private/js_binary.bzl
+@@ -204,6 +204,15 @@ _ATTRS = {
+         which can lead to non-hermetic behavior.""",
+         default = True,
+     ),
++    "use_lstat_patch": attr.bool(
++        doc = """Apply the internal lstat patch to prevent the program from following symlinks out of
++        the execroot, runfiles and the sandbox even when using the ESM loader.
++
++        This flag only has an effect when `patch_node_fs` is True.
++
++        This attribute was added by us (AugmentCode) as a fix for the ESM loader skirting the fs patches.""",
++        default = False,
++    ),
+     "include_sources": attr.bool(
+         doc = """When True, `sources` from `JsInfo` providers in `data` targets are included in the runfiles of the target.""",
+         default = True,
+@@ -564,11 +573,18 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
+     )
+ 
+ def _js_binary_impl(ctx):
++    # Only apply lstat patch if it's requested
++    JS_BINARY__USE_LSTAT_PATCH = "1" if ctx.attr.use_lstat_patch else "0"
++    fixed_env = {
++        "JS_BINARY__USE_LSTAT_PATCH": JS_BINARY__USE_LSTAT_PATCH,
++    }
++
+     launcher = _create_launcher(
+         ctx,
+         log_prefix_rule_set = "aspect_rules_js",
+         log_prefix_rule = "js_test" if ctx.attr.testonly else "js_binary",
+         fixed_args = ctx.attr.fixed_args,
++        fixed_env = fixed_env,
+     )
+     runfiles = launcher.runfiles
+ 
 diff --git a/js/private/node-patches/fs.cjs b/js/private/node-patches/fs.cjs
-index acf3f797..05edbf9d 100644
+index acf3f797..629ff866 100644
 --- a/js/private/node-patches/fs.cjs
 +++ b/js/private/node-patches/fs.cjs
-@@ -46,6 +46,11 @@ const _fs = require('node:fs');
+@@ -46,7 +46,12 @@ const _fs = require('node:fs');
  const url = require('node:url');
  const HOP_NON_LINK = Symbol.for('HOP NON LINK');
  const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND');
+-function patcher(fs = _fs, roots) {
 +// TENZIN IMPORT SECTION
 +const { internalBinding } = require('internal/test/binding');
 +const { getStatsFromBinding } = require('internal/fs/utils');
 +const internalFs = internalBinding('fs');
 +const _originalStatFs = internalFs.lstat;
- function patcher(fs = _fs, roots) {
++function patcher(fs = _fs, roots, useLstatPatch) {
      fs = fs || _fs;
      // Make the original version of the library available for when access to the
+     // unguarded file system is necessary, such as the esbuild plugin that
 @@ -723,6 +728,115 @@ function patcher(fs = _fs, roots) {
              }
          }
@@ -90,7 +134,7 @@ index acf3f797..05edbf9d 100644
 +            throw err;
 +        }
 +    };
-+    if (internalFs.lstat) {
++    if (useLstatPatch && internalFs.lstat) {
 +        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
 +            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
 +            // Better than escaping IMO
@@ -130,23 +174,47 @@ index acf3f797..05edbf9d 100644
  }
  exports.patcher = patcher;
  // =========================================================================
+diff --git a/js/private/node-patches/register.cjs b/js/private/node-patches/register.cjs
+index 944e576a..6636c8f3 100644
+--- a/js/private/node-patches/register.cjs
++++ b/js/private/node-patches/register.cjs
+@@ -5,6 +5,7 @@ const {
+     JS_BINARY__LOG_PREFIX,
+     JS_BINARY__NODE_WRAPPER,
+     JS_BINARY__PATCH_NODE_FS,
++    JS_BINARY__USE_LSTAT_PATCH,
+ } = process.env
+ 
+ // Keep a count of how many times these patches are applied; this should reflect the depth
+@@ -43,7 +44,8 @@ if (
+             `DEBUG: ${JS_BINARY__LOG_PREFIX}: node fs patches will be applied with roots: ${roots}`
+         )
+     }
+-    patchfs(fs, roots)
++    const useLstatPatch = JS_BINARY__USE_LSTAT_PATCH && JS_BINARY__USE_LSTAT_PATCH != '0'
++    patchfs(fs, roots, useLstatPatch)
+ 
+     // Sync the esm modules to use the now patched fs cjs module.
+     // See: https://nodejs.org/api/esm.html#builtin-modules
 diff --git a/js/private/node-patches/src/fs.cts b/js/private/node-patches/src/fs.cts
-index b07d4a1a..26ab6bea 100644
+index b07d4a1a..d551b9c6 100644
 --- a/js/private/node-patches/src/fs.cts
 +++ b/js/private/node-patches/src/fs.cts
-@@ -36,6 +36,12 @@ const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND')
+@@ -36,7 +36,13 @@ const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND')
  
  type HopResults = string | typeof HOP_NON_LINK | typeof HOP_NOT_FOUND
  
+-export function patcher(fs: any = _fs, roots: string[]) {
 +// TENZIN IMPORT SECTION
 +const { internalBinding } = require('internal/test/binding');
 +const { getStatsFromBinding } = require('internal/fs/utils');
 +const internalFs = internalBinding('fs');
 +const _originalStatFs = internalFs.lstat;
 +
- export function patcher(fs: any = _fs, roots: string[]) {
++export function patcher(fs: any = _fs, roots: string[], useLstatPatch: boolean) {
      fs = fs || _fs
      // Make the original version of the library available for when access to the
+     // unguarded file system is necessary, such as the esbuild plugin that
 @@ -819,6 +825,136 @@ export function patcher(fs: any = _fs, roots: string[]) {
              }
          }
@@ -238,7 +306,7 @@ index b07d4a1a..26ab6bea 100644
 +        }
 +    }
 +
-+    if (internalFs.lstat) {
++    if (useLstatPatch && internalFs.lstat) {
 +        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
 +            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
 +            // Better than escaping IMO

--- a/devversion-lstat-patch.patch
+++ b/devversion-lstat-patch.patch
@@ -1,0 +1,296 @@
+diff --git a/js/private/node-patches/fs.cjs b/js/private/node-patches/fs.cjs
+index acf3f797..05edbf9d 100644
+--- a/js/private/node-patches/fs.cjs
++++ b/js/private/node-patches/fs.cjs
+@@ -46,6 +46,11 @@ const _fs = require('node:fs');
+ const url = require('node:url');
+ const HOP_NON_LINK = Symbol.for('HOP NON LINK');
+ const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND');
++// TENZIN IMPORT SECTION
++const { internalBinding } = require('internal/test/binding');
++const { getStatsFromBinding } = require('internal/fs/utils');
++const internalFs = internalBinding('fs');
++const _originalStatFs = internalFs.lstat;
+ function patcher(fs = _fs, roots) {
+     fs = fs || _fs;
+     // Make the original version of the library available for when access to the
+@@ -723,6 +728,115 @@ function patcher(fs = _fs, roots) {
+             }
+         }
+     }
++    // TENZIN PATCH SECTION FOR NODE INTERNAL LSTAT BINDING
++    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
++    const eeguardStats = (path, bigint, stats, cb) => {
++        const statsObj = getStatsFromBinding(stats);
++        if (!statsObj.isSymbolicLink()) {
++            // the file is not a symbolic link so there is nothing more to do
++            return cb(null, stats);
++        }
++        path = resolvePathLike(path);
++        if (!canEscape(path)) {
++            // the file can not escaped the sandbox so there is nothing more to do
++            return cb(null, stats);
++        }
++        return guardedReadLink(path, (str) => {
++            if (str != path) {
++                // there are one or more hops within the guards so there is nothing more to do
++                return cb(null, stats);
++            }
++            // there are no hops so lets report the stats of the real file;
++            // we can't use origRealPath here since that function calls lstat internally
++            // which can result in an infinite loop
++            return unguardedRealPath(path, (err, str) => {
++                if (err) {
++                    if ('code' in err && err.code === 'ENOENT') {
++                        // broken link so there is nothing more to do
++                        return cb(null, stats);
++                    }
++                    return cb(err);
++                }
++                // Forward request to original callback.
++                const req2 = new internalFs.FSReqCallback(bigint);
++                req2.oncomplete = (err, realStats) => cb(err, realStats);
++                return _originalStatFs.call(internalFs, str, bigint, req2);
++            });
++        });
++    };
++    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
++    const eeguardStatsSync = (path, bigint, throwIfNoEntry, stats) => {
++        // No stats available.
++        if (!stats) {
++            return stats;
++        }
++        const statsObj = getStatsFromBinding(stats);
++        if (!statsObj.isSymbolicLink()) {
++            // the file is not a symbolic link so there is nothing more to do
++            return stats;
++        }
++        path = resolvePathLike(path);
++        if (!canEscape(path)) {
++            // the file can not escaped the sandbox so there is nothing more to do
++            return stats;
++        }
++        const guardedReadLink = guardedReadLinkSync(path);
++        if (guardedReadLink != path) {
++            // there are one or more hops within the guards so there is nothing more to do
++            return stats;
++        }
++        try {
++            path = unguardedRealPathSync(path);
++            // there are no hops so lets report the stats of the real file;
++            // we can't use origRealPathSync here since that function calls lstat internally
++            // which can result in an infinite loop
++            return _originalStatFs.call(internalFs, path, bigint, undefined, throwIfNoEntry);
++        }
++        catch (err) {
++            if (err.code === 'ENOENT') {
++                // broken link so there is nothing more to do
++                return stats;
++            }
++            throw err;
++        }
++    };
++    if (internalFs.lstat) {
++        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
++            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
++            // Better than escaping IMO
++            const st = new Error().stack;
++            const needsGuarding = st.includes('finalizeResolution (node:internal/modules/esm/resolve') && !st.includes('eeguardStats');
++            if (!needsGuarding || global.__insidePatchedLstat) {
++                return _originalStatFs
++                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry);
++            }
++            if (typeof reqCallback === 'symbol') {
++                return _originalStatFs
++                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry)
++                    .then((stats) => {
++                    return new Promise((resolve, reject) => {
++                        eeguardStats(path, bigint, stats, (err, guardedStats) => {
++                            err ? reject(err) : resolve(guardedStats);
++                        });
++                    });
++                });
++            }
++            else if (reqCallback !== undefined) {
++                // Just re-use the promise path above.
++                internalFs
++                    .lstat(path, bigint, internalFs.kUsePromises, throwIfNoEntry)
++                    .then((stats) => reqCallback(null, stats))
++                    .catch((err) => reqCallback(err));
++            }
++            else {
++                const stats = _originalStatFs.call(internalFs, path, bigint, undefined, throwIfNoEntry);
++                if (!stats) {
++                    return stats;
++                }
++                return eeguardStatsSync(path, bigint, throwIfNoEntry, stats);
++            }
++        };
++    }
+ }
+ exports.patcher = patcher;
+ // =========================================================================
+diff --git a/js/private/node-patches/src/fs.cts b/js/private/node-patches/src/fs.cts
+index b07d4a1a..26ab6bea 100644
+--- a/js/private/node-patches/src/fs.cts
++++ b/js/private/node-patches/src/fs.cts
+@@ -36,6 +36,12 @@ const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND')
+ 
+ type HopResults = string | typeof HOP_NON_LINK | typeof HOP_NOT_FOUND
+ 
++// TENZIN IMPORT SECTION
++const { internalBinding } = require('internal/test/binding');
++const { getStatsFromBinding } = require('internal/fs/utils');
++const internalFs = internalBinding('fs');
++const _originalStatFs = internalFs.lstat;
++
+ export function patcher(fs: any = _fs, roots: string[]) {
+     fs = fs || _fs
+     // Make the original version of the library available for when access to the
+@@ -819,6 +825,136 @@ export function patcher(fs: any = _fs, roots: string[]) {
+             }
+         }
+     }
++
++    // TENZIN PATCH SECTION FOR NODE INTERNAL LSTAT BINDING
++    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
++    const eeguardStats = (path, bigint, stats, cb) => {
++        const statsObj = getStatsFromBinding(stats);
++        if (!statsObj.isSymbolicLink()) {
++            // the file is not a symbolic link so there is nothing more to do
++            return cb(null, stats)
++        }
++
++        path = resolvePathLike(path)
++        if (!canEscape(path)) {
++            // the file can not escaped the sandbox so there is nothing more to do
++            return cb(null, stats);
++        }
++
++        return guardedReadLink(path, (str) => {
++            if (str != path) {
++                // there are one or more hops within the guards so there is nothing more to do
++                return cb(null, stats);
++            }
++            // there are no hops so lets report the stats of the real file;
++            // we can't use origRealPath here since that function calls lstat internally
++            // which can result in an infinite loop
++            return unguardedRealPath(path, (err, str) => {
++                if (err) {
++                    if ('code' in err && err.code === 'ENOENT') {
++                        // broken link so there is nothing more to do
++                        return cb(null, stats);
++                    }
++                    return cb(err);
++                }
++
++                // Forward request to original callback.
++                const req2 = new internalFs.FSReqCallback(bigint);
++                req2.oncomplete = (err, realStats) => cb(err, realStats);
++                return _originalStatFs.call(internalFs, str, bigint, req2);
++            })
++        })
++    }
++
++    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
++    const eeguardStatsSync = (path, bigint, throwIfNoEntry, stats) => {
++        // No stats available.
++        if (!stats) {
++            return stats
++        }
++
++        const statsObj = getStatsFromBinding(stats);
++        if (!statsObj.isSymbolicLink()) {
++            // the file is not a symbolic link so there is nothing more to do
++            return stats
++        }
++
++        path = resolvePathLike(path)
++        if (!canEscape(path)) {
++            // the file can not escaped the sandbox so there is nothing more to do
++            return stats
++        }
++
++        const guardedReadLink = guardedReadLinkSync(path);
++        if (guardedReadLink != path) {
++            // there are one or more hops within the guards so there is nothing more to do
++            return stats
++        }
++        try {
++            path = unguardedRealPathSync(path);
++
++            // there are no hops so lets report the stats of the real file;
++            // we can't use origRealPathSync here since that function calls lstat internally
++            // which can result in an infinite loop
++            return _originalStatFs.call(
++                internalFs,
++                path,
++                bigint,
++                undefined,
++                throwIfNoEntry
++            );
++        } catch (err) {
++            if (err.code === 'ENOENT') {
++                // broken link so there is nothing more to do
++                return stats;
++            }
++            throw err;
++        }
++    }
++
++    if (internalFs.lstat) {
++        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
++            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
++            // Better than escaping IMO
++            const st = new Error().stack;
++            const needsGuarding =
++                st.includes('finalizeResolution (node:internal/modules/esm/resolve') && !st.includes('eeguardStats');
++            if (!needsGuarding || global.__insidePatchedLstat) {
++                return _originalStatFs
++                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry);
++            }
++
++            if (typeof reqCallback === 'symbol') {
++                return _originalStatFs
++                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry)
++                    .then((stats) => {
++                        return new Promise((resolve, reject) => {
++                            eeguardStats(path, bigint, stats, (err, guardedStats) => {
++                                err ? reject(err) : resolve(guardedStats)
++                            });
++                        });
++                    });
++            } else if (reqCallback !== undefined) {
++                // Just re-use the promise path above.
++                internalFs
++                    .lstat(path, bigint, internalFs.kUsePromises, throwIfNoEntry)
++                    .then((stats) => reqCallback(null, stats))
++                    .catch((err) => reqCallback(err));
++            } else {
++                const stats = _originalStatFs.call(
++                    internalFs,
++                    path,
++                    bigint,
++                    undefined,
++                    throwIfNoEntry
++                );
++                if (!stats) {
++                    return stats
++                }
++                return eeguardStatsSync(path, bigint, throwIfNoEntry, stats);
++            }
++        }
++    }
+ }
+ 
+ // =========================================================================
+diff --git a/js/private/node_wrapper.sh b/js/private/node_wrapper.sh
+index fae2c2a5..7c346a8c 100755
+--- a/js/private/node_wrapper.sh
++++ b/js/private/node_wrapper.sh
+@@ -2,4 +2,4 @@
+ 
+ set -o pipefail -o errexit -o nounset
+ 
+-exec "$JS_BINARY__NODE_BINARY" --require "$JS_BINARY__NODE_PATCHES" "$@"
++exec "$JS_BINARY__NODE_BINARY" --expose-internals --require "$JS_BINARY__NODE_PATCHES" "$@"

--- a/js/private/js_binary.bzl
+++ b/js/private/js_binary.bzl
@@ -204,6 +204,15 @@ _ATTRS = {
         which can lead to non-hermetic behavior.""",
         default = True,
     ),
+    "use_lstat_patch": attr.bool(
+        doc = """Apply the internal lstat patch to prevent the program from following symlinks out of
+        the execroot, runfiles and the sandbox even when using the ESM loader.
+
+        This flag only has an effect when `patch_node_fs` is True.
+
+        This attribute was added by us (AugmentCode) as a fix for the ESM loader skirting the fs patches.""",
+        default = False,
+    ),
     "include_sources": attr.bool(
         doc = """When True, `sources` from `JsInfo` providers in `data` targets are included in the runfiles of the target.""",
         default = True,
@@ -564,11 +573,18 @@ def _create_launcher(ctx, log_prefix_rule_set, log_prefix_rule, fixed_args = [],
     )
 
 def _js_binary_impl(ctx):
+    # Only apply lstat patch if it's requested
+    JS_BINARY__USE_LSTAT_PATCH = "1" if ctx.attr.use_lstat_patch else "0"
+    fixed_env = {
+        "JS_BINARY__USE_LSTAT_PATCH": JS_BINARY__USE_LSTAT_PATCH,
+    }
+
     launcher = _create_launcher(
         ctx,
         log_prefix_rule_set = "aspect_rules_js",
         log_prefix_rule = "js_test" if ctx.attr.testonly else "js_binary",
         fixed_args = ctx.attr.fixed_args,
+        fixed_env = fixed_env,
     )
     runfiles = launcher.runfiles
 

--- a/js/private/node-patches/fs.cjs
+++ b/js/private/node-patches/fs.cjs
@@ -46,6 +46,11 @@ const _fs = require('node:fs');
 const url = require('node:url');
 const HOP_NON_LINK = Symbol.for('HOP NON LINK');
 const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND');
+// TENZIN IMPORT SECTION
+const { internalBinding } = require('internal/test/binding');
+const { getStatsFromBinding } = require('internal/fs/utils');
+const internalFs = internalBinding('fs');
+const _originalStatFs = internalFs.lstat;
 function patcher(fs = _fs, roots) {
     fs = fs || _fs;
     // Make the original version of the library available for when access to the
@@ -722,6 +727,115 @@ function patcher(fs = _fs, roots) {
                 return loc;
             }
         }
+    }
+    // TENZIN PATCH SECTION FOR NODE INTERNAL LSTAT BINDING
+    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
+    const eeguardStats = (path, bigint, stats, cb) => {
+        const statsObj = getStatsFromBinding(stats);
+        if (!statsObj.isSymbolicLink()) {
+            // the file is not a symbolic link so there is nothing more to do
+            return cb(null, stats);
+        }
+        path = resolvePathLike(path);
+        if (!canEscape(path)) {
+            // the file can not escaped the sandbox so there is nothing more to do
+            return cb(null, stats);
+        }
+        return guardedReadLink(path, (str) => {
+            if (str != path) {
+                // there are one or more hops within the guards so there is nothing more to do
+                return cb(null, stats);
+            }
+            // there are no hops so lets report the stats of the real file;
+            // we can't use origRealPath here since that function calls lstat internally
+            // which can result in an infinite loop
+            return unguardedRealPath(path, (err, str) => {
+                if (err) {
+                    if ('code' in err && err.code === 'ENOENT') {
+                        // broken link so there is nothing more to do
+                        return cb(null, stats);
+                    }
+                    return cb(err);
+                }
+                // Forward request to original callback.
+                const req2 = new internalFs.FSReqCallback(bigint);
+                req2.oncomplete = (err, realStats) => cb(err, realStats);
+                return _originalStatFs.call(internalFs, str, bigint, req2);
+            });
+        });
+    };
+    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
+    const eeguardStatsSync = (path, bigint, throwIfNoEntry, stats) => {
+        // No stats available.
+        if (!stats) {
+            return stats;
+        }
+        const statsObj = getStatsFromBinding(stats);
+        if (!statsObj.isSymbolicLink()) {
+            // the file is not a symbolic link so there is nothing more to do
+            return stats;
+        }
+        path = resolvePathLike(path);
+        if (!canEscape(path)) {
+            // the file can not escaped the sandbox so there is nothing more to do
+            return stats;
+        }
+        const guardedReadLink = guardedReadLinkSync(path);
+        if (guardedReadLink != path) {
+            // there are one or more hops within the guards so there is nothing more to do
+            return stats;
+        }
+        try {
+            path = unguardedRealPathSync(path);
+            // there are no hops so lets report the stats of the real file;
+            // we can't use origRealPathSync here since that function calls lstat internally
+            // which can result in an infinite loop
+            return _originalStatFs.call(internalFs, path, bigint, undefined, throwIfNoEntry);
+        }
+        catch (err) {
+            if (err.code === 'ENOENT') {
+                // broken link so there is nothing more to do
+                return stats;
+            }
+            throw err;
+        }
+    };
+    if (internalFs.lstat) {
+        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
+            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
+            // Better than escaping IMO
+            const st = new Error().stack;
+            const needsGuarding = st.includes('finalizeResolution (node:internal/modules/esm/resolve') && !st.includes('eeguardStats');
+            if (!needsGuarding || global.__insidePatchedLstat) {
+                return _originalStatFs
+                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry);
+            }
+            if (typeof reqCallback === 'symbol') {
+                return _originalStatFs
+                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry)
+                    .then((stats) => {
+                    return new Promise((resolve, reject) => {
+                        eeguardStats(path, bigint, stats, (err, guardedStats) => {
+                            err ? reject(err) : resolve(guardedStats);
+                        });
+                    });
+                });
+            }
+            else if (reqCallback !== undefined) {
+                // Just re-use the promise path above.
+                internalFs
+                    .lstat(path, bigint, internalFs.kUsePromises, throwIfNoEntry)
+                    .then((stats) => reqCallback(null, stats))
+                    .catch((err) => reqCallback(err));
+            }
+            else {
+                const stats = _originalStatFs.call(internalFs, path, bigint, undefined, throwIfNoEntry);
+                if (!stats) {
+                    return stats;
+                }
+                return eeguardStatsSync(path, bigint, throwIfNoEntry, stats);
+            }
+        };
     }
 }
 exports.patcher = patcher;

--- a/js/private/node-patches/fs.cjs
+++ b/js/private/node-patches/fs.cjs
@@ -51,7 +51,7 @@ const { internalBinding } = require('internal/test/binding');
 const { getStatsFromBinding } = require('internal/fs/utils');
 const internalFs = internalBinding('fs');
 const _originalStatFs = internalFs.lstat;
-function patcher(fs = _fs, roots) {
+function patcher(fs = _fs, roots, useLstatPatch) {
     fs = fs || _fs;
     // Make the original version of the library available for when access to the
     // unguarded file system is necessary, such as the esbuild plugin that
@@ -800,7 +800,7 @@ function patcher(fs = _fs, roots) {
             throw err;
         }
     };
-    if (internalFs.lstat) {
+    if (useLstatPatch && internalFs.lstat) {
         internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
             // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
             // Better than escaping IMO

--- a/js/private/node-patches/register.cjs
+++ b/js/private/node-patches/register.cjs
@@ -5,6 +5,7 @@ const {
     JS_BINARY__LOG_PREFIX,
     JS_BINARY__NODE_WRAPPER,
     JS_BINARY__PATCH_NODE_FS,
+    JS_BINARY__USE_LSTAT_PATCH,
 } = process.env
 
 // Keep a count of how many times these patches are applied; this should reflect the depth
@@ -43,7 +44,8 @@ if (
             `DEBUG: ${JS_BINARY__LOG_PREFIX}: node fs patches will be applied with roots: ${roots}`
         )
     }
-    patchfs(fs, roots)
+    const useLstatPatch = JS_BINARY__USE_LSTAT_PATCH && JS_BINARY__USE_LSTAT_PATCH != '0'
+    patchfs(fs, roots, useLstatPatch)
 
     // Sync the esm modules to use the now patched fs cjs module.
     // See: https://nodejs.org/api/esm.html#builtin-modules

--- a/js/private/node-patches/src/fs.cts
+++ b/js/private/node-patches/src/fs.cts
@@ -36,6 +36,12 @@ const HOP_NOT_FOUND = Symbol.for('HOP NOT FOUND')
 
 type HopResults = string | typeof HOP_NON_LINK | typeof HOP_NOT_FOUND
 
+// TENZIN IMPORT SECTION
+const { internalBinding } = require('internal/test/binding');
+const { getStatsFromBinding } = require('internal/fs/utils');
+const internalFs = internalBinding('fs');
+const _originalStatFs = internalFs.lstat;
+
 export function patcher(fs: any = _fs, roots: string[]) {
     fs = fs || _fs
     // Make the original version of the library available for when access to the
@@ -816,6 +822,136 @@ export function patcher(fs: any = _fs, roots: string[]) {
             ) {
                 // this hop takes us out of the guard
                 return loc
+            }
+        }
+    }
+
+    // TENZIN PATCH SECTION FOR NODE INTERNAL LSTAT BINDING
+    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
+    const eeguardStats = (path, bigint, stats, cb) => {
+        const statsObj = getStatsFromBinding(stats);
+        if (!statsObj.isSymbolicLink()) {
+            // the file is not a symbolic link so there is nothing more to do
+            return cb(null, stats)
+        }
+
+        path = resolvePathLike(path)
+        if (!canEscape(path)) {
+            // the file can not escaped the sandbox so there is nothing more to do
+            return cb(null, stats);
+        }
+
+        return guardedReadLink(path, (str) => {
+            if (str != path) {
+                // there are one or more hops within the guards so there is nothing more to do
+                return cb(null, stats);
+            }
+            // there are no hops so lets report the stats of the real file;
+            // we can't use origRealPath here since that function calls lstat internally
+            // which can result in an infinite loop
+            return unguardedRealPath(path, (err, str) => {
+                if (err) {
+                    if ('code' in err && err.code === 'ENOENT') {
+                        // broken link so there is nothing more to do
+                        return cb(null, stats);
+                    }
+                    return cb(err);
+                }
+
+                // Forward request to original callback.
+                const req2 = new internalFs.FSReqCallback(bigint);
+                req2.oncomplete = (err, realStats) => cb(err, realStats);
+                return _originalStatFs.call(internalFs, str, bigint, req2);
+            })
+        })
+    }
+
+    // Almost same logic as existing patcher, just that we use `getStatsFromBinding`.
+    const eeguardStatsSync = (path, bigint, throwIfNoEntry, stats) => {
+        // No stats available.
+        if (!stats) {
+            return stats
+        }
+
+        const statsObj = getStatsFromBinding(stats);
+        if (!statsObj.isSymbolicLink()) {
+            // the file is not a symbolic link so there is nothing more to do
+            return stats
+        }
+
+        path = resolvePathLike(path)
+        if (!canEscape(path)) {
+            // the file can not escaped the sandbox so there is nothing more to do
+            return stats
+        }
+
+        const guardedReadLink = guardedReadLinkSync(path);
+        if (guardedReadLink != path) {
+            // there are one or more hops within the guards so there is nothing more to do
+            return stats
+        }
+        try {
+            path = unguardedRealPathSync(path);
+
+            // there are no hops so lets report the stats of the real file;
+            // we can't use origRealPathSync here since that function calls lstat internally
+            // which can result in an infinite loop
+            return _originalStatFs.call(
+                internalFs,
+                path,
+                bigint,
+                undefined,
+                throwIfNoEntry
+            );
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                // broken link so there is nothing more to do
+                return stats;
+            }
+            throw err;
+        }
+    }
+
+    if (internalFs.lstat) {
+        internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
+            // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
+            // Better than escaping IMO
+            const st = new Error().stack;
+            const needsGuarding =
+                st.includes('finalizeResolution (node:internal/modules/esm/resolve') && !st.includes('eeguardStats');
+            if (!needsGuarding || global.__insidePatchedLstat) {
+                return _originalStatFs
+                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry);
+            }
+
+            if (typeof reqCallback === 'symbol') {
+                return _originalStatFs
+                    .call(internalFs, path, bigint, reqCallback, throwIfNoEntry)
+                    .then((stats) => {
+                        return new Promise((resolve, reject) => {
+                            eeguardStats(path, bigint, stats, (err, guardedStats) => {
+                                err ? reject(err) : resolve(guardedStats)
+                            });
+                        });
+                    });
+            } else if (reqCallback !== undefined) {
+                // Just re-use the promise path above.
+                internalFs
+                    .lstat(path, bigint, internalFs.kUsePromises, throwIfNoEntry)
+                    .then((stats) => reqCallback(null, stats))
+                    .catch((err) => reqCallback(err));
+            } else {
+                const stats = _originalStatFs.call(
+                    internalFs,
+                    path,
+                    bigint,
+                    undefined,
+                    throwIfNoEntry
+                );
+                if (!stats) {
+                    return stats
+                }
+                return eeguardStatsSync(path, bigint, throwIfNoEntry, stats);
             }
         }
     }

--- a/js/private/node-patches/src/fs.cts
+++ b/js/private/node-patches/src/fs.cts
@@ -42,7 +42,7 @@ const { getStatsFromBinding } = require('internal/fs/utils');
 const internalFs = internalBinding('fs');
 const _originalStatFs = internalFs.lstat;
 
-export function patcher(fs: any = _fs, roots: string[]) {
+export function patcher(fs: any = _fs, roots: string[], useLstatPatch: boolean) {
     fs = fs || _fs
     // Make the original version of the library available for when access to the
     // unguarded file system is necessary, such as the esbuild plugin that
@@ -912,7 +912,7 @@ export function patcher(fs: any = _fs, roots: string[]) {
         }
     }
 
-    if (internalFs.lstat) {
+    if (useLstatPatch && internalFs.lstat) {
         internalFs.lstat = function (path, bigint, reqCallback, throwIfNoEntry) {
             // This is the nasty part.. — but I didn't spend much time thinking on this. I do think it's acceptable though.
             // Better than escaping IMO

--- a/js/private/node_wrapper.sh
+++ b/js/private/node_wrapper.sh
@@ -2,4 +2,4 @@
 
 set -o pipefail -o errexit -o nounset
 
-exec "$JS_BINARY__NODE_BINARY" --require "$JS_BINARY__NODE_PATCHES" "$@"
+exec "$JS_BINARY__NODE_BINARY" --expose-internals --require "$JS_BINARY__NODE_PATCHES" "$@"


### PR DESCRIPTION
This version of the patch adds a new `use_lstat_patch` attribute to the JS rules that makes the lstat patch opt-in (and opt-out by default).

See #1 for a larger description of why this patch is good or whatever.